### PR TITLE
[ENGG-2130] fix: filteredResources not used when row is selected

### DIFF
--- a/packages/resource-table/src/ResourceTable.tsx
+++ b/packages/resource-table/src/ResourceTable.tsx
@@ -90,13 +90,18 @@ const ResourceTable = <ResourceType,>({
       }
     : {};
 
+  const filteredResources = useMemo(
+    () => (filter ? resources.filter(filter) : resources),
+    [resources, filter],
+  );
+
   const selectedResource = useMemo<ResourceType>(() => {
     if (!selectedRowId) {
       return null;
     }
 
     const selectedRowIndex = getRowIndex(selectedRowId);
-    return resources[selectedRowIndex];
+    return filteredResources[selectedRowIndex];
   }, [selectedRowId]);
 
   const columnsToRender = useMemo<Column<ResourceType>[]>(() => {
@@ -107,11 +112,6 @@ const ResourceTable = <ResourceType,>({
     }
     return columns;
   }, [selectedResource, detailsTabs, primaryColumnKeys]);
-
-  const filteredResources = useMemo(
-    () => (filter ? resources.filter(filter) : resources),
-    [resources, filter],
-  );
 
   useEffect(() => {
     if (selectedResource) {

--- a/packages/resource-table/src/ResourceTable.tsx
+++ b/packages/resource-table/src/ResourceTable.tsx
@@ -102,7 +102,7 @@ const ResourceTable = <ResourceType,>({
 
     const selectedRowIndex = getRowIndex(selectedRowId);
     return filteredResources[selectedRowIndex];
-  }, [selectedRowId]);
+  }, [selectedRowId, filteredResources]);
 
   const columnsToRender = useMemo<Column<ResourceType>[]>(() => {
     if (selectedResource && detailsTabs) {


### PR DESCRIPTION
When resources were filtered then`filteredResources` was not used for the `selectedResource` operation